### PR TITLE
Updated pieChart to use correct width and height

### DIFF
--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -66,8 +66,8 @@ nv.models.pieChart = function() {
             nv.utils.initSVG(container);
 
             var that = this;
-            var availableWidth = nv.utils.availableWidth(width, container, margin),
-                availableHeight = nv.utils.availableHeight(height, container, margin);
+            var availableWidth = nv.utils.availableWidth(pie.width(), container, margin),
+                availableHeight = nv.utils.availableHeight(pie.height(), container, margin);
 
             chart.update = function() { container.transition().call(chart); };
             chart.container = this;


### PR DESCRIPTION
pieChart.js didn't use pie.width() and pie.height() to determine the available width and height. Therefore the available width and height reverted to the width and height of the parent element, which is incorrect behaviour if the width and height are set.
